### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # XeonApps.Extensions.Logging.WithProperty
 [![Version](https://img.shields.io/nuget/v/XeonApps.Extensions.Logging.WithProperty)](https://www.nuget.org/packages/XeonApps.Extensions.Logging.WithProperty)
 
-Extensions methods for adding custom properties to structured logging output when using Microsoft.Extensions.Logging;
+Extension methods for adding custom properties to structured logging output when using Microsoft.Extensions.Logging;
 
 # Installation
 Install-Package XeonApps.Extensions.Logging.WithProperty


### PR DESCRIPTION
## Summary
- fix minor typo in README

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*