### PR TITLE
Fix nested property count and add tests

### DIFF
--- a/XeonApps.Extensions.Logging.WithProperty.Tests/WithPropertyBaseLoggerTests.cs
+++ b/XeonApps.Extensions.Logging.WithProperty.Tests/WithPropertyBaseLoggerTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using XeonApps.Extensions.Logging.WithProperty;
+using Xunit;
+
+namespace XeonApps.Extensions.Logging.WithProperty.Tests
+{
+    public class WithPropertyBaseLoggerTests
+    {
+        private sealed class DummyLogger : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+
+            private sealed class NullDisposable : IDisposable
+            {
+                public static readonly NullDisposable Instance = new NullDisposable();
+                public void Dispose() { }
+            }
+        }
+
+        [Fact]
+        public void Count_ShouldAccumulateAcrossNestedLoggers()
+        {
+            ILogger logger = new DummyLogger();
+            logger = logger.WithProperty("A", 1).WithProperty("B", 2).WithProperty("C", 3);
+
+            var props = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object>>>(logger);
+            Assert.Equal(3, props.Count);
+        }
+
+        [Fact]
+        public void Enumerator_ReturnsAllPropertiesFromNestedLoggers()
+        {
+            ILogger logger = new DummyLogger();
+            logger = logger.WithProperty("A", 1).WithProperty("B", 2).WithProperty("C", 3);
+
+            var props = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object>>>(logger);
+            var keys = new List<string>();
+            foreach (var kv in props)
+            {
+                keys.Add(kv.Key);
+            }
+
+            Assert.Equal(new[] { "C", "B", "A" }, keys);
+        }
+    }
+}

--- a/XeonApps.Extensions.Logging.WithProperty.Tests/XeonApps.Extensions.Logging.WithProperty.Tests.csproj
+++ b/XeonApps.Extensions.Logging.WithProperty.Tests/XeonApps.Extensions.Logging.WithProperty.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XeonApps.Extensions.Logging.WithProperty\XeonApps.Extensions.Logging.WithProperty.csproj" />
+  </ItemGroup>
+</Project>

--- a/XeonApps.Extensions.Logging.WithProperty.sln
+++ b/XeonApps.Extensions.Logging.WithProperty.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XeonApps.Extensions.Logging.WithProperty", "XeonApps.Extensions.Logging.WithProperty\XeonApps.Extensions.Logging.WithProperty.csproj", "{19597F9B-160F-4D27-8703-1193848356B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XeonApps.Extensions.Logging.WithProperty.Tests", "XeonApps.Extensions.Logging.WithProperty.Tests\XeonApps.Extensions.Logging.WithProperty.Tests.csproj", "{D6E05126-3460-4114-9231-FBF5B82EF62C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -10,7 +12,11 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{19597F9B-160F-4D27-8703-1193848356B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19597F9B-160F-4D27-8703-1193848356B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{19597F9B-160F-4D27-8703-1193848356B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{19597F9B-160F-4D27-8703-1193848356B6}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {19597F9B-160F-4D27-8703-1193848356B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {19597F9B-160F-4D27-8703-1193848356B6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {D6E05126-3460-4114-9231-FBF5B82EF62C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D6E05126-3460-4114-9231-FBF5B82EF62C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D6E05126-3460-4114-9231-FBF5B82EF62C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D6E05126-3460-4114-9231-FBF5B82EF62C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/XeonApps.Extensions.Logging.WithProperty/WithPropertyBaseLogger.cs
+++ b/XeonApps.Extensions.Logging.WithProperty/WithPropertyBaseLogger.cs
@@ -74,7 +74,7 @@ namespace XeonApps.Extensions.Logging.WithProperty
       return GetEnumerator();
     }
 
-    public int Count => PropertiesCount + (_next?.PropertiesCount ?? 0);
+    public int Count => PropertiesCount + (_next?.Count ?? 0);
 
     public KeyValuePair<string, object> this[int index]
     {


### PR DESCRIPTION
## Summary
- fix property count calculation in WithPropertyBaseLogger
- add unit tests for nested logger cases

## Testing
- `dotnet test XeonApps.Extensions.Logging.WithProperty.sln` *(fails: dotnet not found)*